### PR TITLE
Fixing typo in package.json. Previously the output for style.css woul…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "basic snake game written in Typescript",
   "main": "src/index.ts",
   "scripts": {
-    "build": "tsc && rollup -c && node-sass --output-style compressed style.scss > build/style.css;echo 'Build Done.'",
+    "build": "tsc && rollup -c && node-sass --output-style compressed style.scss > build/style.css && echo 'Build Done.'",
     "start": "live-server . --watch=build"
   },
   "repository": {


### PR DESCRIPTION
…d get placed into a file named ";echo" at the root of the project. Replaced it with && as believed to be originally intended.